### PR TITLE
https://media.tenor.com/images/d1a95af2649146d3f6956c3f463ab64c/tenor.gif

### DIFF
--- a/VenomMusic/modules/play.py
+++ b/VenomMusic/modules/play.py
@@ -100,7 +100,7 @@ async def generate_cover(requested_by, title, views, duration, thumbnail):
     Image.alpha_composite(image5, image6).save("temp.png")
     img = Image.open("temp.png")
     draw = ImageDraw.Draw(img)
-    font = ImageFont.truetype("etc/font.otf", 32)
+    font = ImageFont.opentype("etc/font.otf", 32)
     draw.text((205, 550), f"Title: {title}", (51, 215, 255), font=font)
     draw.text((205, 590), f"Duration: {duration}", (255, 255, 255), font=font)
     draw.text((205, 630), f"Views: {views}", (255, 255, 255), font=font)


### PR DESCRIPTION
.